### PR TITLE
Add compare button and fix Scenescript browser

### DIFF
--- a/wwwroot/dbc/index.html
+++ b/wwwroot/dbc/index.html
@@ -102,7 +102,7 @@
                data-toggle='modal' href='' data-target='#foreignKeySearchModal'><i class='fa fa-search'></i> FK Search</a>
             <a style='vertical-align: top;' id='globalSearchButton' class='btn btn-secondary btn-sm'
                data-toggle='modal' href='' data-target='#globalSearchModal'><i class='fa fa-search'></i> Global Search</a>
-            <a style='vertical-align: top;' id='compareButton' class='btn btn-secondary btn-sm' href=''><i class='fa fa-search'></i> Compare</a>
+            <a style='vertical-align: top;' id='compareButton' class='btn btn-secondary btn-sm' href='/dbc/diff.html'><i class='fa fa-search'></i> Compare</a>
             <div class="btn-group" style="vertical-align: top">
                 <a style='vertical-align: top;' id='updateDefsButton' class='btn btn-danger btn-sm' onclick="updateDefs();" href="#"><i class='fa fa-refresh'></i> Update WoWDBDefs & clear cache</a>
                 <a style='vertical-align: top;' id='reloadDefsButton' class='btn btn-danger btn-sm' onclick="reloadDefs();" href="#"><i class='fa fa-refresh'></i> Clear DB2/DBC/DBD cache</a>
@@ -514,6 +514,8 @@
         function updateCompareButtonHref() {
             // Script to dynamically set the href of the compare button based on the currently selected dbc
             let dbc = currentParams["dbc"];
+            if (dbc == "")
+                return;
             let button = document.getElementById("compareButton");
             button.href = "/dbc/diff.html?dbc=" + dbc;
         }

--- a/wwwroot/dbc/index.html
+++ b/wwwroot/dbc/index.html
@@ -102,6 +102,7 @@
                data-toggle='modal' href='' data-target='#foreignKeySearchModal'><i class='fa fa-search'></i> FK Search</a>
             <a style='vertical-align: top;' id='globalSearchButton' class='btn btn-secondary btn-sm'
                data-toggle='modal' href='' data-target='#globalSearchModal'><i class='fa fa-search'></i> Global Search</a>
+            <a style='vertical-align: top;' id='compareButton' class='btn btn-secondary btn-sm' href=''><i class='fa fa-search'></i> Compare</a>
             <div class="btn-group" style="vertical-align: top">
                 <a style='vertical-align: top;' id='updateDefsButton' class='btn btn-danger btn-sm' onclick="updateDefs();" href="#"><i class='fa fa-refresh'></i> Update WoWDBDefs & clear cache</a>
                 <a style='vertical-align: top;' id='reloadDefsButton' class='btn btn-danger btn-sm' onclick="reloadDefs();" href="#"><i class='fa fa-refresh'></i> Clear DB2/DBC/DBD cache</a>
@@ -509,6 +510,13 @@
         }
 
         loadSettings();
+
+        function updateCompareButtonHref() {
+            // Script to dynamically set the href of the compare button based on the currently selected dbc
+            let dbc = currentParams["dbc"];
+            let button = document.getElementById("compareButton");
+            button.href = "/dbc/diff.html?dbc=" + dbc;
+        }
 
         function toggleFilters() {
             if (!Settings.filtersCurrentlyEnabled) {
@@ -970,6 +978,8 @@
             //            hotfixedIDs = data;
             //        });
             //}
+
+            updateCompareButtonHref() // update the compare button link
 
             $.ajax({
                 "url": "/dbc/header/" + currentParams["dbc"] + "/?build=" + currentParams["build"],

--- a/wwwroot/dbc/scenescript.html
+++ b/wwwroot/dbc/scenescript.html
@@ -110,13 +110,17 @@
         <div id='tableContainer'><table id='dbtable' class="table table-striped table-bordered table-condensed" cellspacing="0" width="100%"><thead></thead><tbody></tbody></table></div>
         <div id='scriptContainer'></div>
         <script type='text/javascript'>
+            let currentParams = [];
+
             $('#buildFilter').on('change', function () {
                 var build = $("#buildFilter").val();
                 document.location = '/dbc/scenescript.html?build=' + build;
+                currentParams["build"] = build;
             });
 
             let knownManifests = new Array();
             var build = $("#buildFilter").val();
+            currentParams["build"] = build;
             const scriptContainer = document.getElementById("scriptContainer");
             const loadingHolder = document.getElementById("loadingHolder");
             async function loadSceneScript(packageid, build) {
@@ -134,7 +138,7 @@
                 hljs.highlightBlock(scriptContainer);
                 loadingHolder.innerText = "";
 
-            }
+            }   
 
             async function handlePackageMember(packageMember) {
                 if (packageMember.ChildSceneScriptPackageID != 0) {
@@ -193,7 +197,6 @@
             }
 
             function loadTable() {
-                currentParams["build"] = "10.1.5.49516";
                 build = currentParams["build"];
 
                 $("#dbtable").html("<tbody><tr><td style='text-align: center' id='loadingMessage'>Select a table in the dropdown above</td></tr></tbody>");
@@ -329,8 +332,6 @@
                 });
             }
 
-            let currentParams = [];
-            currentParams["build"] = "10.1.5.49516";
             (function () {
 
                 hljs.configure({ languages: ['lua'] });

--- a/wwwroot/js/enums.js
+++ b/wwwroot/js/enums.js
@@ -64,7 +64,7 @@ const itemBonusTypes = {
     31: 'LegendaryName',
     34: 'ItemBonusListGroupID',
     35: 'ItemLimitCategoryID',
-    37: 'ItemConversion',
+    37: 'ItemConversionID',
     42: 'Base Item Level',
 };
 

--- a/wwwroot/js/enums.js
+++ b/wwwroot/js/enums.js
@@ -63,7 +63,9 @@ const itemBonusTypes = {
     30: 'ItemDescription',
     31: 'LegendaryName',
     34: 'ItemBonusListGroupID',
-    35: 'ItemLimitCategoryID'
+    35: 'ItemLimitCategoryID',
+    37: 'ItemConversion',
+    42: 'Base Item Level',
 };
 
 const criteriaTreeOperator = {


### PR DESCRIPTION
Adds a compare button to the DBC browse page so you don't have to go to the dropdown and then select the table again. Also fixes the Scenescript browser so it loads the currently selected build instead of a hardcoded one.

Also updates the ItemBonusTypes Enum