### PR TITLE
Item texture and particle colour improvements

### DIFF
--- a/wwwroot/mv/index.html
+++ b/wwwroot/mv/index.html
@@ -171,6 +171,14 @@
                             <input type='text' id='tex16' name='textures[16]'> <label for='tex16'>Texture #16</label><br>
                             <input type='text' id='tex17' name='textures[17]'> <label for='tex17'>Texture #17</label><br>
                             <input type='text' id='tex18' name='textures[18]'> <label for='tex18'>Texture #18</label><br>
+                            <input type='text' id='tex19' name='textures[19]'> <label for='tex19'>Texture #19</label><br>
+                            <input type='text' id='tex20' name='textures[20]'> <label for='tex20'>Texture #20</label><br>
+                            <input type='text' id='tex21' name='textures[21]'> <label for='tex21'>Texture #21</label><br>
+                            <input type='text' id='tex22' name='textures[22]'> <label for='tex22'>Texture #22</label><br>
+                            <input type='text' id='tex23' name='textures[23]'> <label for='tex23'>Texture #23</label><br>
+                            <input type='text' id='tex24' name='textures[24]'> <label for='tex24'>Texture #24</label><br>
+                            <input type='text' id='tex25' name='textures[25]'> <label for='tex25'>Texture #25</label><br>
+                            <input type='text' id='tex26' name='textures[26]'> <label for='tex26'>Texture #26</label><br>
                         </form>
                         <button type="button" class="btn btn-primary" onclick="updateTextures();" data-dismiss="modal">Save</button>
                     </div>


### PR DESCRIPTION
Change item/ models to use all 4 potential texture slots, not just the first one. Also, enable particle colour settings for item/ models when they're set in itemDisplayInfo.