### PR TITLE
Add several enums, flags, and FKs, and make sure they're shown on index/hotfixes pages

### DIFF
--- a/wwwroot/dbc/hotfixes.html
+++ b/wwwroot/dbc/hotfixes.html
@@ -273,8 +273,29 @@
                 }
             }
 
-            if (enumMap.has(dbc.toLowerCase() + "." + col)) {
-                var enumRes = enumMap.get(dbc.toLowerCase() + "." + col);
+            const columnWithTable = dbc.toLowerCase() + "." + col
+            if (conditionalEnums.has(columnWithTable)) {
+                let conditionalEnum = conditionalEnums.get(columnWithTable);
+                conditionalEnum.forEach(function (conditionalEnumEntry) {
+                    let condition = conditionalEnumEntry[0].split('=');
+                    let conditionTarget = condition[0].split('.');
+                    let conditionValue = condition[1];
+                    let resultEnum = conditionalEnumEntry[1];
+                    let colTarget = Object.keys(row).indexOf(conditionTarget[1]);
+
+                    // Col target found?
+                    if (colTarget > -1) {
+                        if (row[conditionTarget[1]] == conditionValue) {
+                            if (val in resultEnum) {
+                                returnedValue += " (" + resultEnum[val] + ")";
+                            } else {
+                                returnedValue += " (unknown)";
+                            }
+                        }
+                    }
+                });
+            } else if (enumMap.has(columnWithTable)) {
+                var enumRes = enumMap.get(columnWithTable);
                 if (val in enumRes) {
                     if (Array.isArray(enumRes[val])) {
                         returnedValue += " (" + enumRes[val][1] + ")";

--- a/wwwroot/dbc/index.html
+++ b/wwwroot/dbc/index.html
@@ -1092,7 +1092,8 @@
                                 let fk = "";
                                 if (meta.col in fkCols) {
                                     fk = fkCols[meta.col];
-                                } else if (conditionalFKs.has(columnWithTable)) {
+                                }
+                                if (conditionalFKs.has(columnWithTable)) {
                                     let conditionalFK = conditionalFKs.get(columnWithTable);
                                     conditionalFK.forEach(function (conditionalFKEntry) {
                                         let condition = conditionalFKEntry[0].split(

--- a/wwwroot/js/enums.js
+++ b/wwwroot/js/enums.js
@@ -1482,6 +1482,49 @@ const spellVisualKitEffectType = {
     19: 'SpellVisualScreenEffectID',
 }
 
+const spellModOp = {
+    0: 'HealingAndDamage',
+    1: 'Duration',
+    2: 'Hate',
+    3: 'PointsIndex0',
+    4: 'ProcCharges',
+    5: 'Range',
+    6: 'Radius',
+    7: 'CritChance',
+    8: 'Points',
+    9: 'ResistPushback',
+    10: 'ChangeCastTime',
+    11: 'Cooldown',
+    12: 'PointsIndex1',
+    13: 'TargetResistance',
+    14: 'PowerCost0', // Used when SpellPowerEntry::PowerIndex == 0
+    15: 'CritDamageAndHealing',
+    16: 'HitChance',
+    17: 'ChainTargets',
+    18: 'ProcChance',
+    19: 'Period',
+    20: 'ChainAmplitude',
+    21: 'StartCooldown',
+    22: 'PeriodicHealingAndDamage',
+    23: 'PointsIndex2',
+    24: 'BonusCoefficient',
+    25: 'TriggerDamage', // NYI
+    26: 'ProcFrequency',
+    27: 'Amplitude',
+    28: 'DispelResistance',
+    29: 'CrowdDamage', // NYI
+    30: 'PowerCostOnMiss',
+    31: 'Doses',
+    32: 'PointsIndex3',
+    33: 'PointsIndex4',
+    34: 'PowerCost1', // Used when SpellPowerEntry::PowerIndex == 1
+    35: 'ChainJumpDistance',
+    36: 'AreaTriggerMaxSummons', // NYI
+    37: 'MaxAuraStacks',
+    38: 'ProcCooldown',
+    39: 'PowerCost2', // Used when SpellPowerEntry::PowerIndex == 2
+}
+
 const spellLabelName = {
     // 12: '12',
     16: 'Player (???)',
@@ -5890,6 +5933,15 @@ for (let i = 0; i < 3; i++){
         ]
     );
 }
+
+conditionalEnums.set("spelleffect.EffectMiscValue[0]",
+    [
+        ['spelleffect.EffectAura=107', spellModOp],
+        ['spelleffect.EffectAura=108', spellModOp],
+        ['spelleffect.EffectAura=218', spellModOp],
+        ['spelleffect.EffectAura=219', spellModOp],
+    ]
+);
 
 // Conditional FKs (move to sep file?)
 conditionalFKs.set("itembonus.Value[0]",

--- a/wwwroot/js/enums.js
+++ b/wwwroot/js/enums.js
@@ -5932,6 +5932,11 @@ for (let i = 0; i < 3; i++){
             ['spellitemenchantment.Effect[' + i + ']=5', itemStatType]
         ]
     );
+    conditionalFKs.set("spellitemenchantment.EffectArg[" + i + "]",
+        [
+            ['spellitemenchantment.Effect[' + i + ']=4', 'resistances::id']
+        ]
+    );
 }
 
 conditionalEnums.set("spelleffect.EffectMiscValue[0]",

--- a/wwwroot/js/flags.js
+++ b/wwwroot/js/flags.js
@@ -2824,3 +2824,22 @@ conditionalFlags.set("chrcustomizationreq.ReqValue",
         ['chrcustomizationreq.ReqType=1', classMask],
     ]
 );
+
+conditionalFlags.set("spelleffect.EffectMiscValue[0]",
+    [
+        ['spelleffect.EffectAura=39', damageClass],
+        ['spelleffect.EffectAura=69', damageClass],
+        ['spelleffect.EffectAura=71', damageClass],
+        ['spelleffect.EffectAura=72', damageClass],
+        ['spelleffect.EffectAura=73', damageClass],
+        ['spelleffect.EffectAura=74', damageClass],
+        ['spelleffect.EffectAura=194', damageClass],
+        // ['spelleffect.EffectAura=195', damageClass], // Classic-only, spell FK in Retail
+        // ['spelleffect.EffectAura=205', damageClass], // Classic-only, Unknown in Retail
+        ['spelleffect.EffectAura=220', damageClass], // Retail-only, CombatRatings flag in Classic
+        ['spelleffect.EffectAura=267', damageClass],
+        ['spelleffect.EffectAura=270', damageClass],
+        ['spelleffect.EffectAura=301', damageClass],
+        ['spelleffect.EffectAura=316', damageClass], // Retail-only, Unknown in Classic
+    ]
+);

--- a/wwwroot/js/flags.js
+++ b/wwwroot/js/flags.js
@@ -2118,6 +2118,48 @@ const materialFlags = {
     0x00000004: 'Is Chain',
 }
 
+// 407
+const procTypeMask0 = {
+    0x00000001: 'Heartbeat',
+    0x00000002: 'Kill',
+    0x00000004: 'Deal Melee Swing',
+    0x00000008: 'Take Melee Swing',
+    0x00000010: 'Deal Melee Ability',
+    0x00000020: 'Take Melee Ability',
+    0x00000040: 'Deal Ranged Attack',
+    0x00000080: 'Take Ranged Attack',
+    0x00000100: 'Deal Ranged Ability',
+    0x00000200: 'Take Ranged Ability',
+    0x00000400: 'Deal Helpful Ability',
+    0x00000800: 'Take Helpful Ability',
+    0x00001000: 'Deal Harmful Ability',
+    0x00002000: 'Take Harmful Ability',
+    0x00004000: 'Deal Helpful Spell',
+    0x00008000: 'Take Helpful Spell',
+    0x00010000: 'Deal Harmful Spell',
+    0x00020000: 'Take Harmful Spell',
+    0x00040000: 'Deal Harmful Periodic',
+    0x00080000: 'Take Harmful Periodic',
+    0x00100000: 'Take Any Damage - DO NOT USE',
+    0x00200000: 'Deal Helpful Periodic',
+    0x00400000: 'Main Hand Weapon Swing',
+    0x00800000: 'Off Hand Weapon Swing',
+    0x01000000: 'Death',
+    0x02000000: 'Jump',
+    0x04000000: 'Proc Clone Spell',
+    0x08000000: 'Enter Combat',
+    0x10000000: 'Encounter Start',
+    0x20000000: 'Cast Ended',
+    0x40000000: 'Looted',
+    0x80000000: 'Take Helpful Periodic',
+}
+
+const procTypeMask1 = {
+    0x00000001: 'Target Dies',
+    0x00000002: 'Knockback',
+    0x00000004: 'Cast Successful',
+}
+
 // 436
 const spellCategoryFlags = {
     0x00000001: 'Cooldown modifies item',
@@ -2718,6 +2760,8 @@ window.flagMap.set("skillline.Flags", skillLineFlags);
 window.flagMap.set("soundambience.Flags", soundAmbienceFlags);
 window.flagMap.set("soundemitters.Flags", soundEmitterFlags);
 window.flagMap.set("soundkit.Flags", soundkitFlags);
+window.flagMap.set("spellauraoptions.ProcTypeMask[0]", procTypeMask0)
+window.flagMap.set("spellauraoptions.ProcTypeMask[1]", procTypeMask1)
 window.flagMap.set("spellcastingrequirements.FacingCasterFlags", facingCasterFlags);
 window.flagMap.set("spelleffect.EffectAttributes", spellEffectEffectAttributes);
 window.flagMap.set("spellinterrupts.AuraInterruptFlags[0]", auraInterruptFlags0);


### PR DESCRIPTION
Most of these are straightforward; conditionalFKs weren't showing on dbc/index, and conditionalEnums weren't showing on dbc/hotfixes, so I added those.

spellModOp is from https://wowdev.wiki/AuraEffect::CalculateSpellMod(), procTypeMask was checked against both wiki and EnumeratedStrings.

d3157513f3e64c872c77ccb2af0a6b4b9e67d4f4 has a few questionable things. Some of the EffectAuras are now different between Classic and Retail. I added the conditions assuming Retail takes precedent, but left the differences Classic has as comments.
