### PR TITLE
Add fallbacks for dbc endpoints

### DIFF
--- a/Controllers/DBC/DataController.cs
+++ b/Controllers/DBC/DataController.cs
@@ -32,6 +32,10 @@ namespace wow.tools.local.Controllers
         [HttpGet("{name}"), HttpPost("{name}")]
         public async Task<DataTablesResult> Get(string name, string build, int draw, int start, int length, CancellationToken cancellationToken, bool useHotfixes = false, LocaleFlags locale = LocaleFlags.All_WoW)
         {
+            name = name.ToLower();
+            if (string.IsNullOrEmpty(build) || build == "?" || build == "null")
+                build = CASC.BuildName;
+
             var parameters = new Dictionary<string, string>();
 
             if (Request.Method == "POST")

--- a/Controllers/DBC/FindController.cs
+++ b/Controllers/DBC/FindController.cs
@@ -96,6 +96,10 @@ namespace wow.tools.local.Controllers.DBC
         [HttpGet("{name}")]
         public async Task<List<Dictionary<string, string>>> Get(string name, string build, string col, int val, bool useHotfixes = false, bool calcOffset = true)
         {
+            name = name.ToLower();
+            if (string.IsNullOrEmpty(build) || build == "?" || build == "null")
+                build = CASC.BuildName;
+
             Console.WriteLine("Finding results for " + name + "::" + col + " (" + build + ", hotfixes: " + useHotfixes + ") value " + val);
 
             var storage = await dbcManager.GetOrLoad(name, build, useHotfixes);

--- a/Controllers/DBC/HeaderController.cs
+++ b/Controllers/DBC/HeaderController.cs
@@ -41,9 +41,11 @@ namespace wow.tools.local.Controllers.DBC
         [HttpGet("{name}")]
         public async Task<HeaderResult> Get(string name, string build)
         {
-            Console.WriteLine("Serving headers for " + name + " (" + build + ")");
-            if (build == "?")
+            name = name.ToLower();
+            if (string.IsNullOrEmpty(build) || build == "?" || build == "null")
                 build = CASC.BuildName;
+
+            Console.WriteLine("Serving headers for " + name + " (" + build + ")");
 
             var result = new HeaderResult();
             try


### PR DESCRIPTION
These fallbacks make the SceneScript viewer work again