### PR TITLE
Fix `fancyFlagTable`

### DIFF
--- a/wwwroot/js/dbc.js
+++ b/wwwroot/js/dbc.js
@@ -238,7 +238,7 @@ function getFlagDescriptions(db, field, value, targetFlags = 0){
 }
 
 function fancyFlagTable(flagArrs){
-    if (flagArrs.length == 0){
+    if (flagArrs.length == 0 || typeof flagArrs[0] !== 'object') {
         return "";
     }
 


### PR DESCRIPTION
The use of this is being passed by `getFlagDescriptions`. When BigInt is undefined or the value is `-1`, it returns a flat object (e.g. `['All']`.

When this attempts to pretty print, it will return a table consisting of `<td>A</td><td>l</td>`, which is buggy obviously :)