### PR TITLE
Fix for codespace setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+    "postCreateCommand": "git submodule update --init",
+}


### PR DESCRIPTION
Codespaces on GitHub don't clone recursively so initial project setup fails unless you manually nuget restore.

This is purely QoL so I get something to do at work in between builds.