### PR TITLE
Format changes for Build & Diff pages.

### DIFF
--- a/wwwroot/builds/diff.html
+++ b/wwwroot/builds/diff.html
@@ -104,8 +104,6 @@
                 pageLength: 25,
                 autoWidth: false,
                 layout: {
-                    topStart: null,
-                    topEnd: null,
                     bottomEnd: 'inputPaging'
                 },
                 deferRender: true,
@@ -286,7 +284,7 @@
     </script>
     <div class='container-fluid' id='diffContainer'>
         <h3>Showing differences between <span id="fromBuildName"></span> and <span id="toBuildName"></span><span id='summary'></span></h3>
-        <table id='buildtable' class='table table-sm table-hover maintable'>
+        <table id='buildtable' class='table table-striped table-sm table-hover maintable'>
             <thead>
                 <tr class="filters"  data-dt-order="disable">
                     <th class="filterable"></th>
@@ -296,7 +294,7 @@
                 </tr>
                 <tr>
                     <th style='width: 80px'>Action</th>
-                    <th style='width: 120px;'>FileData ID</th>
+                    <th style='width: 80px;'>FDID</th>
                     <th>Filename</th>
                     <th style='width: 50px'>Type</th>
                     <th style='width: 25px'>&nbsp;</th>

--- a/wwwroot/builds/index.html
+++ b/wwwroot/builds/index.html
@@ -98,7 +98,7 @@
                 type: "POST"
             },
             "order": [[1, 'desc']],
-            "lengthMenu": [[25, 100, 500, 1000], [25, 100, 500, 1000]],
+            "lengthChange": false,
             "columnDefs": [
                 {
                     "targets": [2, 3, 4, 5, 6, 7, 8],


### PR DESCRIPTION
- fixed page length selector for diff page (the null values were breaking it)
- added striping to the diff file list, which mirrors the regular file list (it seems handy to me, but feel free to remove if you hate it)
- removed the page length selector from the builds page as it didn't seem necessary (unless some people have dozens of builds listed but that doesn't seem likely?)