### PR TITLE
Adjust background of hamburger menu button in modelviewer

### DIFF
--- a/wwwroot/css/modelviewer.css
+++ b/wwwroot/css/modelviewer.css
@@ -69,7 +69,7 @@ html, body{
     width: 30px;
     height: 30px;
     border: 0;
-    background-color: rgba(255,255,255,.5);
+    background-color: rgba(183, 183, 183, 0.5);
     transition: background-color 0.1s ease;
     border-radius: 10%;
     outline: none;


### PR DESCRIPTION
Adjust background of hamburger menu button in modelviewer so it's not entirely invisible when the background is white.

There's always a possibility that part of the element will be hidden against certain backgrounds, but not entirely unless the background and element colour are identical (which they are currently).