### PR TITLE
Fix linebreaks on WTL-suggestions downloads on Firefox-based browsers

### DIFF
--- a/wwwroot/files/naming.html
+++ b/wwwroot/files/naming.html
@@ -352,7 +352,7 @@
 
         function resultsAsTxt() {
             var fakeLink = document.createElement("a");
-            fakeLink.href = "data:text/plain;charset=UTF-8," + result.value;
+            fakeLink.href = "data:text/plain;charset=UTF-8," + encodeURIComponent(result.value);
             fakeLink.setAttribute("download", "WTL-suggestions.txt");
             fakeLink.click();
         }


### PR DESCRIPTION
Using Firefox the downloaded file did not contain any line breaks. URI encoding the generated text made sure to preserve the line breaks when downloading.

Tested the expected behaviour on:

- Firefox 141.0b9 (Windows x64)
- Microsoft Edge 138.0.3551.83 (Windows x64)
- Chromium 138.0.7204.100 (Windows x64)