### PR TITLE
Ensure that the cache directory exists when downloading db defs for the first time after installation

### DIFF
--- a/Services/DBDProvider.cs
+++ b/Services/DBDProvider.cs
@@ -38,6 +38,9 @@ namespace wow.tools.Services
 
             if (downloadBDBD)
             {
+                if(!Directory.Exists("cache"))
+                    Directory.CreateDirectory("cache");
+
                 using (var client = new HttpClient())
                 {
                     client.DefaultRequestHeaders.Add("User-Agent", "wow.tools.local");
@@ -71,7 +74,7 @@ namespace wow.tools.Services
                     {
                         var name = Path.GetFileNameWithoutExtension(entry.Key);
                         var definition = entry.Value.dbd;
-                        
+
                         definitionLookup.Add(name, (entry.Key, definition));
                     }
                     Console.WriteLine("Loaded " + definitionLookup.Count + " definitions from BDBD file!");


### PR DESCRIPTION
A small low hanging fruit found while debugging.
Turns out when we don't set up the dbd defs manually in config, it attempts to download the defs into the cache folder without making sure that the cache already exists which throws directory not found exceptions. 

This case can be reproduced when building and starting the tool with default configs for the first time