### PR TITLE
Kill case sensitivity issues for Linux, allowing dbc/db2 files to load regardless of casing

### DIFF
--- a/Controllers/DBC/InfoController.cs
+++ b/Controllers/DBC/InfoController.cs
@@ -56,6 +56,7 @@ namespace wow.tools.local.Controllers
                     string directoryPath = Path.Combine(SettingsManager.DBCFolder, build, "dbfilesclient");
                     if (Directory.Exists(directoryPath))
                     {
+                        // Try to either find a db2 or dbc file, ignoring casing to maintain identical behavior on all platforms
                         string? fileName = Directory.EnumerateFiles(directoryPath).FirstOrDefault(fn =>
                             fn.EndsWith($"{db2}.db2", StringComparison.OrdinalIgnoreCase) ||
                             fn.EndsWith($"{db2}.dbc", StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
We now allow dbc/db2 files to have any kind of casing on all platforms.

This fixes platform specific issues with case sensitivity on Linux in which all files had to be lowercase. We can now use raw extracted data just fine.

This also means that the readme note

> Depending on operating system, the DBC/DB2 names might need to be lowercase

Is no longer valid and can be removed.
