### PR TITLE
Fixed copying config.json into output directory

### DIFF
--- a/wow.tools.local.csproj
+++ b/wow.tools.local.csproj
@@ -60,6 +60,8 @@
     <None Remove="wow-filetags\**" />
     <None Remove="WoWFormatLib\**" />
     <None Remove="WoWNamingLib\**" />
+    <Content Remove="config.json" />
+    <None Include="config.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -69,7 +71,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Remove="config.json" />
     <Content Remove="knownPushIDs.json" />
     <Content Remove="versionHistory.json" />
     <Content Remove="wwwroot\db\broadcasttext.html" />


### PR DESCRIPTION
Right now, releases do not ship the config.json file as it's currently not referenced by the csproj file. This is fixed now and building the project copies the json file when it's newer